### PR TITLE
ISLE v.1.3.0 Release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN touch /var/log/cron.log && \
 
 # Environment
 ENV TOMCAT_MAJOR=${TOMCAT_MAJOR:-8} \
-    TOMCAT_VERSION=${TOMCAT_VERSION:-8.5.43} \
+    TOMCAT_VERSION=${TOMCAT_VERSION:-8.5.45} \
     CATALINA_HOME=/usr/local/tomcat \
     CATALINA_BASE=/usr/local/tomcat \
     CATALINA_PID=/usr/local/tomcat/tomcat.pid \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Designed as the base image for ISLE components requiring Tomcat and OpenJDK Java
 
 Based on:  
  - [Adopt OpenJDK 8 Docker Image](https://hub.docker.com/r/adoptopenjdk/openjdk8)
- - [Tomcat 8.5.42](https://tomcat.apache.org/)
+ - [Tomcat 8.5.45](https://tomcat.apache.org/)
 
 Contains and Includes:
   - `cron` and `tmpreaper` to clean /tmp *and* /usr/local/tomcat/temp


### PR DESCRIPTION
* `adoptopenjdk/openjdk8` base image (security updates)
* Server package management updates via `apt-get`
* Updated `GEN_DEP_PACKS` dependencies via `apt-get`
* Upgraded `tomcat` to `8.5.45`