### PR TITLE
ISLE-v.1.5 Release -  Updates to README & software"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN GEN_DEP_PACKS="cron \
 
 ## S6-Overlay
 # @see: https://github.com/just-containers/s6-overlay
-ENV S6_OVERLAY_VERSION=${S6_OVERLAY_VERSION:-1.22.1.0}
+ENV S6_OVERLAY_VERSION=${S6_OVERLAY_VERSION:-2.0.0.1}
 ADD https://github.com/just-containers/s6-overlay/releases/download/v$S6_OVERLAY_VERSION/s6-overlay-amd64.tar.gz /tmp/
 RUN tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
     rm /tmp/s6-overlay-amd64.tar.gz
@@ -40,7 +40,7 @@ RUN touch /var/log/cron.log && \
 ## Tomcat Environment
 # @see: https://tomcat.apache.org/
 ENV TOMCAT_MAJOR=${TOMCAT_MAJOR:-8} \
-    TOMCAT_VERSION=${TOMCAT_VERSION:-8.5.55} \
+    TOMCAT_VERSION=${TOMCAT_VERSION:-8.5.57} \
     CATALINA_HOME=/usr/local/tomcat \
     CATALINA_BASE=/usr/local/tomcat \
     CATALINA_PID=/usr/local/tomcat/tomcat.pid \

--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@
 Designed as the base image for ISLE components requiring Tomcat and OpenJDK Java. These include Solr, Image Services, and Fedora.
 
 Based on:  
- - [Adopt OpenJDK 8 Docker Image](https://hub.docker.com/r/adoptopenjdk/openjdk8)
- - [Tomcat 8.5.x](https://tomcat.apache.org/)
+* [Adopt OpenJDK 8 Docker Image](https://hub.docker.com/r/adoptopenjdk/openjdk8)
+* [Tomcat 8.5.x](https://tomcat.apache.org/)
 
 Contains and Includes:
-  - `cron` and `tmpreaper` to clean /tmp *and* /usr/local/tomcat/temp
-  - Tomcat Native library
-  - [confd](http://www.confd.io/)
+* `cron` and `tmpreaper` to clean /tmp *and* /usr/local/tomcat/temp
+* Tomcat Native library
+* [confd](http://www.confd.io/)
 
 ## Important Paths
-  - $CATALINA_HOME is `/usr/local/tomcat`
+* $CATALINA_HOME is `/usr/local/tomcat`
 
 ## Java Options
- - See [Dockerfile](https://github.com/Islandora-Collaboration-Group/isle-tomcat/blob/master/Dockerfile) for default ENV values.
+* See [Dockerfile](https://github.com/Islandora-Collaboration-Group/isle-tomcat/blob/master/Dockerfile) for default ENV values.
 
 ## Usage
 
@@ -24,5 +24,6 @@ Contains and Includes:
   * [Solr](https://github.com/Islandora-Collaboration-Group/isle-solr)
   * [Image Services](https://github.com/Islandora-Collaboration-Group/isle-imageservices)
   * [Fedora](https://github.com/Islandora-Collaboration-Group/isle-fedora)
+  * [Blazegraph](https://github.com/Islandora-Collaboration-Group/isle-blazegraph)
 
 * For general usage of this image and [ISLE](https://github.com/Islandora-Collaboration-Group/ISLE), please refer to [ISLE documentation](https://islandora-collaboration-group.github.io/ISLE/)


### PR DESCRIPTION
* `adoptopenjdk/openjdk8` base image (security updates)
* `apt-get` dist-upgrades for dependencies (sec updates)
* `S6 overlay` upgraded to [2.0.0.1](https://github.com/just-containers/s6-overlay/releases/tag/v2.0.0.1)
* `tomcat` upgraded to `8.5.57`